### PR TITLE
Broker

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ What is Bitcoins current price?
 ## Roadmap
 
 - [x] Uncensored tool calling model
-- [ ] Multi-gateway response routing and queuing
+- [x] Multi-gateway response routing and queuing
 - [ ] Persistent conversation history (multi-user context)
 - [ ] Support for images, files, and URLs to search in a prompt
 - [ ] STT & TTS support

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/jonahgcarpenter/oswald-ai/internal/agent"
 	"github.com/jonahgcarpenter/oswald-ai/internal/config"
 	"github.com/jonahgcarpenter/oswald-ai/internal/gateway"
+	"github.com/jonahgcarpenter/oswald-ai/internal/gateway/broker"
 	"github.com/jonahgcarpenter/oswald-ai/internal/ollama"
 	"github.com/jonahgcarpenter/oswald-ai/internal/tools"
 )
@@ -57,12 +58,18 @@ func main() {
 		log,
 	)
 
+	// Create the broker and start its worker pool.
+	// All gateways submit requests through the broker; it enforces the concurrency
+	// limit and routes responses back to the originating gateway.
+	requestBroker := broker.NewBroker(agentEngine, cfg.WorkerPoolSize, log)
+	requestBroker.Start()
+
 	// Boot up all registered gateways dynamically
 	log.Info("Starting Oswald AI...")
 	for _, gw := range activeGateways {
 		// Pass 'gw' into the closure to avoid loop variable capture bugs
 		go func(g gateway.Service) {
-			if err := g.Start(agentEngine); err != nil {
+			if err := g.Start(requestBroker); err != nil {
 				log.Error("%s gateway stopped/failed: %v", g.Name(), err)
 			}
 		}(gw)
@@ -77,4 +84,8 @@ func main() {
 	<-stop // The main thread will pause here indefinitely until a signal is received
 
 	log.Info("Shutting down Oswald AI gracefully...")
+
+	// Drain the broker: stop accepting new requests and wait for all in-flight
+	// Process() calls to complete before the process exits.
+	requestBroker.Shutdown()
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,14 +9,15 @@ import (
 
 // Config holds all runtime configuration loaded from environment variables.
 type Config struct {
-	Port          string // HTTP port for the WebSocket gateway (default: "8080")
-	OllamaURL     string // Ollama API base URL (default: "http://localhost:11434")
-	WorkersConfig string // Path to the workers YAML file (default: "config/workers.yaml")
-	ToolsConfig   string // Path to the tools directory (default: "config/tools")
-	DiscordToken  string // Discord bot token; Discord gateway disabled if empty
-	SearxngURL    string // SearXNG base URL for web search (default: "http://localhost:8888")
-	MaxIterations int    // Maximum tool-call iterations in the agentic loop (default: 5)
-	LogLevel      Level  // Logging verbosity (default: LevelInfo)
+	Port           string // HTTP port for the WebSocket gateway (default: "8080")
+	OllamaURL      string // Ollama API base URL (default: "http://localhost:11434")
+	WorkersConfig  string // Path to the workers YAML file (default: "config/workers.yaml")
+	ToolsConfig    string // Path to the tools directory (default: "config/tools")
+	DiscordToken   string // Discord bot token; Discord gateway disabled if empty
+	SearxngURL     string // SearXNG base URL for web search (default: "http://localhost:8888")
+	MaxIterations  int    // Maximum tool-call iterations in the agentic loop (default: 5)
+	WorkerPoolSize int    // Number of concurrent broker workers (default: 1)
+	LogLevel       Level  // Logging verbosity (default: LevelInfo)
 }
 
 // Load reads configuration from environment variables, with .env file support.
@@ -26,14 +27,15 @@ func Load() *Config {
 	godotenv.Load() // nolint: errcheck
 
 	return &Config{
-		Port:          getEnv("PORT", "8080"),
-		OllamaURL:     getEnv("OLLAMA_URL", "http://localhost:11434"),
-		WorkersConfig: getEnv("WORKERS_CONFIG", "config/workers.yaml"),
-		ToolsConfig:   getEnv("TOOLS_CONFIG", "config/tools"),
-		DiscordToken:  getEnv("DISCORD_TOKEN", ""),
-		SearxngURL:    getEnv("SEARXNG_URL", "http://localhost:8888"),
-		MaxIterations: getEnvInt("MAX_ITERATIONS", 5),
-		LogLevel:      ParseLevel(getEnv("LOG_LEVEL", "info")),
+		Port:           getEnv("PORT", "8080"),
+		OllamaURL:      getEnv("OLLAMA_URL", "http://localhost:11434"),
+		WorkersConfig:  getEnv("WORKERS_CONFIG", "config/workers.yaml"),
+		ToolsConfig:    getEnv("TOOLS_CONFIG", "config/tools"),
+		DiscordToken:   getEnv("DISCORD_TOKEN", ""),
+		SearxngURL:     getEnv("SEARXNG_URL", "http://localhost:8888"),
+		MaxIterations:  getEnvInt("MAX_ITERATIONS", 5),
+		WorkerPoolSize: getEnvInt("WORKER_POOL_SIZE", 1),
+		LogLevel:       ParseLevel(getEnv("LOG_LEVEL", "info")),
 	}
 }
 

--- a/internal/gateway/broker/broker.go
+++ b/internal/gateway/broker/broker.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	// requestQueueSize is the maximum number of requests that can be buffered
-	// in the broker channel before Submit blocks callers.
+	// in the broker channel before Submit rejects new callers.
 	requestQueueSize = 10
 )
 
@@ -70,13 +70,24 @@ func (b *Broker) Start() {
 	b.log.Info("Broker started with %d worker(s)", b.workerCount)
 }
 
-// Submit enqueues a request for processing. It blocks if the internal queue is
-// full (i.e., all workers are busy and requestQueueSize requests are already
-// waiting). The caller must set req.ResponseChan to a buffered(1) channel before
+// Submit enqueues a request for processing. If the internal queue is full
+// (i.e., all workers are busy and requestQueueSize requests are already
+// waiting), it immediately returns a hardcoded response to the caller instead of
+// blocking. The caller must set req.ResponseChan to a buffered(1) channel before
 // calling Submit; the broker will write exactly one result to it.
 func (b *Broker) Submit(req *Request) {
 	b.log.Debug("Broker: queuing request from %s (chatID=%s)", req.Channel, req.ChatID)
-	b.requests <- req
+
+	select {
+	case b.requests <- req:
+	default:
+		b.log.Warn("Broker: rejecting request from %s (chatID=%s): queue full", req.Channel, req.ChatID)
+		req.ResponseChan <- Result{
+			Response: &agent.AgentResponse{
+				Response: "The queue is full, Try again later or help fragsap buy a new GPU to fix these issues.",
+			},
+		}
+	}
 }
 
 // Shutdown closes the request channel, signalling all workers to stop after

--- a/internal/gateway/broker/broker.go
+++ b/internal/gateway/broker/broker.go
@@ -1,0 +1,112 @@
+package broker
+
+import (
+	"sync"
+
+	"github.com/jonahgcarpenter/oswald-ai/internal/agent"
+	"github.com/jonahgcarpenter/oswald-ai/internal/config"
+)
+
+const (
+	// requestQueueSize is the maximum number of requests that can be buffered
+	// in the broker channel before Submit blocks callers.
+	requestQueueSize = 50
+)
+
+// Request carries a single user request from a gateway into the broker.
+// The gateway populates routing metadata, the user prompt, and an optional
+// stream callback for real-time token delivery. The broker writes exactly
+// one Result to ResponseChan when processing completes.
+type Request struct {
+	Channel      string                  // Gateway name (e.g., "discord", "websocket")
+	ChatID       string                  // Conversation/room identifier
+	SenderID     string                  // User identifier
+	SessionKey   string                  // Unique conversation context key
+	Prompt       string                  // The user's message text
+	StreamFunc   func(agent.StreamChunk) // Optional: streaming callback (nil for non-streaming gateways)
+	ResponseChan chan Result             // Broker writes the final result here; must be buffered(1)
+}
+
+// Result is the response payload the broker delivers back to the originating
+// gateway via Request.ResponseChan.
+type Result struct {
+	Response *agent.AgentResponse
+	Err      error
+}
+
+// Broker sits between gateways and the agent. It owns a fixed-size worker pool
+// that consumes Requests from a shared channel and routes responses back to the
+// originating gateway via each request's ResponseChan.
+//
+// This decouples gateway transport logic from agent processing and provides
+// concurrency control: at most workerCount requests are processed in parallel,
+// with excess requests queued in the channel.
+type Broker struct {
+	agent       *agent.Agent
+	requests    chan *Request
+	workerCount int
+	wg          sync.WaitGroup
+	log         *config.Logger
+}
+
+// NewBroker creates a Broker with the given agent, fixed worker pool size,
+// and logger. Call Start() to begin dispatching requests.
+func NewBroker(aiAgent *agent.Agent, workerCount int, log *config.Logger) *Broker {
+	return &Broker{
+		agent:       aiAgent,
+		requests:    make(chan *Request, requestQueueSize),
+		workerCount: workerCount,
+		log:         log,
+	}
+}
+
+// Start launches the worker pool goroutines. Each worker processes requests
+// from the shared channel until it is closed by Shutdown().
+func (b *Broker) Start() {
+	for i := range b.workerCount {
+		b.wg.Add(1)
+		go b.runWorker(i + 1)
+	}
+	b.log.Info("Broker started with %d worker(s)", b.workerCount)
+}
+
+// Submit enqueues a request for processing. It blocks if the internal queue is
+// full (i.e., all workers are busy and requestQueueSize requests are already
+// waiting). The caller must set req.ResponseChan to a buffered(1) channel before
+// calling Submit; the broker will write exactly one result to it.
+func (b *Broker) Submit(req *Request) {
+	b.log.Debug("Broker: queuing request from %s (chatID=%s)", req.Channel, req.ChatID)
+	b.requests <- req
+}
+
+// Shutdown closes the request channel, signalling all workers to stop after
+// draining any queued requests, then waits for all in-flight Process() calls
+// to complete before returning. New Submit() calls must not be made after
+// Shutdown() is called.
+func (b *Broker) Shutdown() {
+	b.log.Info("Broker: shutting down, draining %d queued request(s)...", len(b.requests))
+	close(b.requests)
+	b.wg.Wait()
+	b.log.Info("Broker: all workers stopped")
+}
+
+// runWorker is the body of a single broker worker goroutine. It reads
+// Requests from the shared channel, calls Agent.Process(), and delivers
+// the result back to the gateway via the request's ResponseChan.
+func (b *Broker) runWorker(id int) {
+	defer b.wg.Done()
+	b.log.Debug("Broker worker %d started", id)
+
+	for req := range b.requests {
+		b.log.Debug("Broker worker %d: processing request from %s (chatID=%s)", id, req.Channel, req.ChatID)
+
+		resp, err := b.agent.Process(req.Prompt, req.StreamFunc)
+
+		req.ResponseChan <- Result{
+			Response: resp,
+			Err:      err,
+		}
+	}
+
+	b.log.Debug("Broker worker %d stopped", id)
+}

--- a/internal/gateway/broker/broker.go
+++ b/internal/gateway/broker/broker.go
@@ -10,7 +10,7 @@ import (
 const (
 	// requestQueueSize is the maximum number of requests that can be buffered
 	// in the broker channel before Submit blocks callers.
-	requestQueueSize = 50
+	requestQueueSize = 10
 )
 
 // Request carries a single user request from a gateway into the broker.

--- a/internal/gateway/discord/gateway.go
+++ b/internal/gateway/discord/gateway.go
@@ -123,7 +123,7 @@ func (dg *Gateway) listenLoop(conn *gorilla.Conn) error {
 				case "MESSAGE_CREATE":
 					var msg MessageCreate
 					if err := json.Unmarshal(p.D, &msg); err == nil {
-						dg.handleMessage(msg)
+						go dg.handleMessage(msg)
 					}
 				}
 			}

--- a/internal/gateway/discord/gateway.go
+++ b/internal/gateway/discord/gateway.go
@@ -11,7 +11,7 @@ import (
 
 	gorilla "github.com/gorilla/websocket"
 
-	"github.com/jonahgcarpenter/oswald-ai/internal/agent"
+	"github.com/jonahgcarpenter/oswald-ai/internal/gateway/broker"
 )
 
 // Name returns the human-readable gateway name.
@@ -21,8 +21,8 @@ func (dg *Gateway) Name() string {
 
 // Start initializes the resilient connection loop.
 // It blocks forever, automatically reconnecting if the websocket drops.
-func (dg *Gateway) Start(aiAgent *agent.Agent) error {
-	dg.Agent = aiAgent
+func (dg *Gateway) Start(b *broker.Broker) error {
+	dg.Broker = b
 
 	for {
 		err := dg.connectAndListen()
@@ -273,13 +273,25 @@ func (dg *Gateway) handleMessage(msg MessageCreate) {
 		}
 	}()
 
-	finalPayload, err := dg.Agent.Process(prompt, nil)
-	if err != nil {
-		dg.Log.Error("Agent process error: %v", err)
+	req := &broker.Request{
+		Channel:      "discord",
+		ChatID:       msg.ChannelID,
+		SenderID:     msg.Author.ID,
+		SessionKey:   msg.ChannelID,
+		Prompt:       prompt,
+		StreamFunc:   nil,
+		ResponseChan: make(chan broker.Result, 1),
+	}
+	dg.Broker.Submit(req)
+	result := <-req.ResponseChan
+
+	if result.Err != nil {
+		dg.Log.Error("Agent process error: %v", result.Err)
 		dg.sendMessage(msg.ChannelID, "Sorry, I encountered an internal error processing that.", replyToID) // nolint: errcheck
 		return
 	}
 
+	finalPayload := result.Response
 	responseText := finalPayload.Response
 	chunks := splitMessage(responseText, 2000)
 
@@ -292,8 +304,7 @@ func (dg *Gateway) handleMessage(msg MessageCreate) {
 			currentReplyID = replyToID
 		}
 
-		err = dg.sendMessage(msg.ChannelID, chunk, currentReplyID)
-		if err != nil {
+		if err := dg.sendMessage(msg.ChannelID, chunk, currentReplyID); err != nil {
 			dg.Log.Error("Failed to send chunk %d to Discord: %v", i+1, err)
 			break
 		}

--- a/internal/gateway/discord/types.go
+++ b/internal/gateway/discord/types.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"time"
 
-	"github.com/jonahgcarpenter/oswald-ai/internal/agent"
 	"github.com/jonahgcarpenter/oswald-ai/internal/config"
+	"github.com/jonahgcarpenter/oswald-ai/internal/gateway/broker"
 )
 
 const (
@@ -61,8 +61,8 @@ type MessageCreate struct {
 
 // Gateway runs the Discord gateway connection loop.
 type Gateway struct {
-	Token string
-	BotID string
-	Agent *agent.Agent
-	Log   *config.Logger
+	Token  string
+	BotID  string
+	Broker *broker.Broker
+	Log    *config.Logger
 }

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -1,21 +1,13 @@
 package gateway
 
-import "github.com/jonahgcarpenter/oswald-ai/internal/agent"
+import "github.com/jonahgcarpenter/oswald-ai/internal/gateway/broker"
 
+// Service is the contract every gateway implementation must satisfy.
+// Start receives a Broker for submitting agent requests and should block
+// for the lifetime of the gateway.
 type Service interface {
 	// Start should block and run the gateway.
 	// Returning an error means it crashed or failed to start.
-	Start(aiAgent *agent.Agent) error
+	Start(b *broker.Broker) error
 	Name() string
-}
-
-// AgentRequest is reserved for future request routing across multiple gateways.
-// TODO: Implement a message broker/multiplexer to route responses back to the correct gateway.
-// Currently, messages are not routed by gateway (responses are broadcast or directed by context).
-// This structure prepares for multi-gateway request attribution.
-type AgentRequest struct {
-	Channel    string // Gateway name (e.g., "discord", "websocket")
-	ChatID     string // Conversation/room identifier
-	SenderID   string // User identifier
-	SessionKey string // Unique conversation context identifier
 }

--- a/internal/gateway/websocket/gateway.go
+++ b/internal/gateway/websocket/gateway.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/jonahgcarpenter/oswald-ai/internal/agent"
 	"github.com/jonahgcarpenter/oswald-ai/internal/config"
+	"github.com/jonahgcarpenter/oswald-ai/internal/gateway/broker"
 )
 
 // Name returns the human-readable gateway name.
@@ -14,17 +15,17 @@ func (wg *Gateway) Name() string {
 }
 
 // Start initializes the HTTP server and registers the WebSocket handler.
-func (wg *Gateway) Start(aiAgent *agent.Agent) error {
+func (wg *Gateway) Start(b *broker.Broker) error {
 	http.HandleFunc("/ws", func(w http.ResponseWriter, r *http.Request) {
-		handleConnections(w, r, aiAgent, wg.Log)
+		handleConnections(w, r, b, wg.Log)
 	})
 
 	wg.Log.Info("Websocket server listening on port %s", wg.Port)
 	return http.ListenAndServe(":"+wg.Port, nil)
 }
 
-// handleConnections accepts WebSocket connections and routes prompts to the agent.
-func handleConnections(w http.ResponseWriter, r *http.Request, aiAgent *agent.Agent, log *config.Logger) {
+// handleConnections accepts WebSocket connections and routes prompts to the broker.
+func handleConnections(w http.ResponseWriter, r *http.Request, b *broker.Broker, log *config.Logger) {
 	conn, err := upgrader.Upgrade(w, r, nil)
 	if err != nil {
 		log.Error("Upgrader error: %v", err)
@@ -56,24 +57,33 @@ func handleConnections(w http.ResponseWriter, r *http.Request, aiAgent *agent.Ag
 			conn.WriteMessage(messageType, chunkBytes) // nolint: errcheck
 		}
 
-		finalPayload, err := aiAgent.Process(userPrompt, streamFunc)
-		if err != nil {
-			log.Error("Engine processing error: %v", err)
+		req := &broker.Request{
+			Channel:      "websocket",
+			ChatID:       "",
+			SenderID:     "",
+			Prompt:       userPrompt,
+			StreamFunc:   streamFunc,
+			ResponseChan: make(chan broker.Result, 1),
+		}
+		b.Submit(req)
+		result := <-req.ResponseChan
+
+		if result.Err != nil {
+			log.Error("Engine processing error: %v", result.Err)
 			errorPayload := agent.AgentResponse{Error: "Internal engine timeout or failure"}
 			errBytes, _ := json.Marshal(errorPayload)
 			conn.WriteMessage(messageType, errBytes) // nolint: errcheck
 			continue
 		}
 
-		jsonBytes, err := json.Marshal(finalPayload)
+		jsonBytes, err := json.Marshal(result.Response)
 		if err != nil {
 			log.Error("Failed to marshal JSON payload: %v", err)
 			continue
 		}
 
-		log.Debug("Websocket: sending final payload (%d bytes, model=%s)", len(jsonBytes), finalPayload.Model)
-		err = conn.WriteMessage(messageType, jsonBytes)
-		if err != nil {
+		log.Debug("Websocket: sending final payload (%d bytes, model=%s)", len(jsonBytes), result.Response.Model)
+		if err = conn.WriteMessage(messageType, jsonBytes); err != nil {
 			log.Debug("Websocket write error: %v", err)
 			break
 		}

--- a/internal/gateway/websocket/gateway.go
+++ b/internal/gateway/websocket/gateway.go
@@ -57,6 +57,8 @@ func handleConnections(w http.ResponseWriter, r *http.Request, b *broker.Broker,
 			conn.WriteMessage(messageType, chunkBytes) // nolint: errcheck
 		}
 
+		// NOTE: This is fine since websocket is only used for testing locally
+		// But for any further implementation I will need to generate IDs here
 		req := &broker.Request{
 			Channel:      "websocket",
 			ChatID:       "",

--- a/test/queueing.go
+++ b/test/queueing.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// responsePayload mirrors the final JSON payload
+type responsePayload struct {
+	Model string `json:"model"`
+	Error string `json:"error"`
+}
+
+// chunkPayload helps detect the first stream token
+type chunkPayload struct {
+	Type string `json:"type"`
+}
+
+type requestStats struct {
+	ID               int
+	SubmitTime       time.Time
+	ProcessStartTime time.Time
+	EndTime          time.Time
+	Error            error
+}
+
+func main() {
+	port := "8080"
+	u := url.URL{Scheme: "ws", Host: "localhost:" + port, Path: "/ws"}
+
+	// We send 12 requests.
+	// Worker pool = 1 (Active)
+	// Queue size = 10 (Buffered)
+	// The 12th request will force b.Submit to block, testing backpressure safely.
+	totalRequests := 12
+
+	fmt.Printf("Starting Queue & FIFO Test against %s...\n", u.String())
+	fmt.Printf("Sending %d concurrent requests to test limits...\n\n", totalRequests)
+
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	results := make([]requestStats, 0, totalRequests)
+
+	for i := 1; i <= totalRequests; i++ {
+		wg.Add(1)
+
+		// Fire each request in a concurrent goroutine
+		go func(reqID int) {
+			defer wg.Done()
+
+			stats := requestStats{ID: reqID}
+
+			conn, _, err := websocket.DefaultDialer.Dial(u.String(), nil)
+			if err != nil {
+				stats.Error = fmt.Errorf("dial error: %v", err)
+				saveResult(&mu, &results, stats)
+				return
+			}
+			defer conn.Close()
+
+			prompt := fmt.Sprintf("Reply with the exact number %d and absolutely nothing else.", reqID)
+
+			// Record submission time
+			stats.SubmitTime = time.Now()
+			if err := conn.WriteMessage(websocket.TextMessage, []byte(prompt)); err != nil {
+				stats.Error = fmt.Errorf("write error: %v", err)
+				saveResult(&mu, &results, stats)
+				return
+			}
+
+			firstTokenReceived := false
+
+			// Read loop
+			for {
+				_, message, err := conn.ReadMessage()
+				if err != nil {
+					stats.Error = fmt.Errorf("read error: %v", err)
+					break
+				}
+
+				// Check if this is the first streamed chunk.
+				// This indicates the worker has pulled this request from the queue
+				// and the LLM has actively started processing it.
+				if !firstTokenReceived {
+					var chunk chunkPayload
+					if err := json.Unmarshal(message, &chunk); err == nil && chunk.Type != "" {
+						stats.ProcessStartTime = time.Now()
+						firstTokenReceived = true
+					}
+				}
+
+				// Check if it's the final payload
+				var finalResp responsePayload
+				if err := json.Unmarshal(message, &finalResp); err == nil && finalResp.Model != "" {
+					stats.EndTime = time.Now()
+					if finalResp.Error != "" {
+						stats.Error = fmt.Errorf("agent error: %s", finalResp.Error)
+					}
+					break
+				}
+			}
+
+			saveResult(&mu, &results, stats)
+		}(i)
+
+		// Stagger submissions by 100ms. This guarantees the HTTP server
+		// receives and queues them in exact sequential order (1, 2, 3...)
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	// Wait for all 12 LLM generations to finish
+	wg.Wait()
+
+	// Sort results by ID so we can evaluate FIFO order
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].ID < results[j].ID
+	})
+
+	fmt.Println("--------------------------------------------------------------------------------")
+	fmt.Printf("%-6s | %-15s | %-15s | %-15s | %s\n", "REQ ID", "QUEUE WAIT TIME", "PROCESSING TIME", "TOTAL TIME", "STATUS")
+	fmt.Println("--------------------------------------------------------------------------------")
+
+	fifoPassed := true
+
+	for i, r := range results {
+		if r.Error != nil {
+			fmt.Printf("%-6d | ERROR: %v\n", r.ID, r.Error)
+			continue
+		}
+
+		queueWait := r.ProcessStartTime.Sub(r.SubmitTime)
+		processingTime := r.EndTime.Sub(r.ProcessStartTime)
+		totalTime := r.EndTime.Sub(r.SubmitTime)
+
+		fmt.Printf("#%-5d | %-15v | %-15v | %-15v | OK\n",
+			r.ID,
+			queueWait.Round(time.Millisecond),
+			processingTime.Round(time.Millisecond),
+			totalTime.Round(time.Millisecond),
+		)
+
+		// Validate FIFO: Request N must start processing AFTER Request N-1
+		if i > 0 {
+			prev := results[i-1]
+			if r.ProcessStartTime.Before(prev.ProcessStartTime) {
+				fifoPassed = false
+				fmt.Printf("\n[!] FIFO VIOLATION: Request %d started processing before Request %d!\n", r.ID, prev.ID)
+			}
+		}
+	}
+	fmt.Println("--------------------------------------------------------------------------------")
+
+	if fifoPassed {
+		fmt.Println("FIFO Test Passed: All requests were processed in chronological order.")
+		fmt.Println("Queue Limit Passed: Server handled 12 concurrent requests (1 active, 10 queued, 1 backpressured) without dropping connections.")
+	} else {
+		fmt.Println("Test Failed: Requests were processed out of order.")
+	}
+}
+
+func saveResult(mu *sync.Mutex, results *[]requestStats, stats requestStats) {
+	mu.Lock()
+	defer mu.Unlock()
+	*results = append(*results, stats)
+}

--- a/test/queueing.go
+++ b/test/queueing.go
@@ -13,8 +13,9 @@ import (
 
 // responsePayload mirrors the final JSON payload
 type responsePayload struct {
-	Model string `json:"model"`
-	Error string `json:"error"`
+	Model    string `json:"model"`
+	Response string `json:"response"`
+	Error    string `json:"error"`
 }
 
 // chunkPayload helps detect the first stream token
@@ -27,8 +28,11 @@ type requestStats struct {
 	SubmitTime       time.Time
 	ProcessStartTime time.Time
 	EndTime          time.Time
+	Response         string
 	Error            error
 }
+
+const queueFullMessage = "The queue is full, Try again later or help fragsap buy a new GPU to fix these issues."
 
 func main() {
 	port := "8080"
@@ -37,7 +41,7 @@ func main() {
 	// We send 12 requests.
 	// Worker pool = 1 (Active)
 	// Queue size = 10 (Buffered)
-	// The 12th request will force b.Submit to block, testing backpressure safely.
+	// The 12th request should be rejected immediately with the queue-full response.
 	totalRequests := 12
 
 	fmt.Printf("Starting Queue & FIFO Test against %s...\n", u.String())
@@ -97,8 +101,9 @@ func main() {
 
 				// Check if it's the final payload
 				var finalResp responsePayload
-				if err := json.Unmarshal(message, &finalResp); err == nil && finalResp.Model != "" {
+				if err := json.Unmarshal(message, &finalResp); err == nil && (finalResp.Model != "" || finalResp.Response != "" || finalResp.Error != "") {
 					stats.EndTime = time.Now()
+					stats.Response = finalResp.Response
 					if finalResp.Error != "" {
 						stats.Error = fmt.Errorf("agent error: %s", finalResp.Error)
 					}
@@ -134,6 +139,23 @@ func main() {
 			continue
 		}
 
+		if r.ID == totalRequests {
+			if r.Response != queueFullMessage {
+				fifoPassed = false
+				fmt.Printf("#%-5d | ERROR: expected queue rejection %q, got %q\n", r.ID, queueFullMessage, r.Response)
+				continue
+			}
+
+			totalTime := r.EndTime.Sub(r.SubmitTime)
+			fmt.Printf("#%-5d | %-15s | %-15s | %-15v | REJECTED\n",
+				r.ID,
+				"n/a",
+				"n/a",
+				totalTime.Round(time.Millisecond),
+			)
+			continue
+		}
+
 		queueWait := r.ProcessStartTime.Sub(r.SubmitTime)
 		processingTime := r.EndTime.Sub(r.ProcessStartTime)
 		totalTime := r.EndTime.Sub(r.SubmitTime)
@@ -158,7 +180,7 @@ func main() {
 
 	if fifoPassed {
 		fmt.Println("FIFO Test Passed: All requests were processed in chronological order.")
-		fmt.Println("Queue Limit Passed: Server handled 12 concurrent requests (1 active, 10 queued, 1 backpressured) without dropping connections.")
+		fmt.Println("Queue Limit Passed: Server handled 12 concurrent requests (1 active, 10 queued, 1 rejected) with the expected queue-full response.")
 	} else {
 		fmt.Println("Test Failed: Requests were processed out of order.")
 	}


### PR DESCRIPTION
- new env var for WORKER_POOL_SIZE to limit concurrent ollama request (default 1)
- new broker setup so each gateway uses a global queue (10), actively rejecting the 12th request
- correctly routing request back to the origin

This config sets up the future context/memory feature with metadata about the origin
