### PR TITLE
fix: removing task as a memory category

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -172,7 +172,7 @@ Oswald keeps three distinct memory layers.
 - Stored in `data/database/oswald.db` tables `user_memory_profiles` and `memory_entries`
 - Managed by the `memory.*` tools
 - Includes an intro line that identifies the current speaker across linked accounts
-- Organized into categories like `identity`, `system_rules`, `communication_preferences`, `durable_preferences`, `projects`, `relationships`, `environment`, `tasks`, and `notes`
+- Organized into categories like `identity`, `system_rules`, `communication_preferences`, `durable_preferences`, `projects`, `relationships`, `environment`, and `notes`
 - `<id>` is now Oswald's canonical internal user ID, not a raw gateway account ID
 - Only the `system_rules` category is injected automatically into the system prompt; other categories are retrieved on demand via tools
 

--- a/data/tools/memory.list.md
+++ b/data/tools/memory.list.md
@@ -11,5 +11,5 @@ Do not use this for normal memory retrieval during conversation; use memory.sear
 | Name     | Type    | Required | Description                                                                                                                                                                |
 | -------- | ------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | scope    | string  | no       | Optional scope filter: `short_term` or `long_term`.                                                                                                                        |
-| category | string  | no       | Optional category filter: `identity`, `system_rules`, `communication_preferences`, `durable_preferences`, `projects`, `relationships`, `environment`, `tasks`, or `notes`. |
+| category | string  | no       | Optional category filter: `identity`, `system_rules`, `communication_preferences`, `durable_preferences`, `projects`, `relationships`, `environment`, or `notes`. |
 | limit    | integer | no       | Maximum memories to return; defaults to 25.                                                                                                                                |

--- a/data/tools/memory.save.md
+++ b/data/tools/memory.save.md
@@ -4,7 +4,7 @@
 
 Save a grounded memory about the current user when it is likely to remain useful beyond this turn. You should manage user memory proactively; the user does not need to explicitly say "remember this."
 
-Use this for stable or recurring facts about the current user's identity, preferences, communication style, projects, relationships, environment, tasks, or standing instructions. Also use this when the user corrects something you previously believed or when a new fact should replace an older memory.
+Use this for stable or recurring facts about the current user's identity, preferences, communication style, projects, relationships, environment, or standing instructions. Also use this when the user corrects something you previously believed or when a new fact should replace an older memory.
 
 Do not save trivial one-off conversation details, temporary wording, public facts, web search results, facts about unrelated people/groups, or Oswald's own identity/personality/directives. Use soul tools for Oswald's own identity and standing behavior.
 
@@ -15,7 +15,7 @@ Do not save trivial one-off conversation details, temporary wording, public fact
 | statement  | string  | yes      | Concise third-person declarative memory, using `the user` instead of first person or second person.                                                        |
 | evidence   | string  | no       | Verbatim quote or concise evidence grounding the memory.                                                                                                   |
 | scope      | string  | no       | `short_term` for active/temporary context or `long_term` for durable facts; defaults to `short_term`.                                                      |
-| category   | string  | no       | Category: `identity`, `system_rules`, `communication_preferences`, `durable_preferences`, `projects`, `relationships`, `environment`, `tasks`, or `notes`. |
+| category   | string  | no       | Category: `identity`, `system_rules`, `communication_preferences`, `durable_preferences`, `projects`, `relationships`, `environment`, or `notes`. |
 | importance | integer | no       | Importance from 1 to 5; defaults to 3.                                                                                                                     |
 | confidence | number  | no       | Confidence from 0.0 to 1.0; defaults to 0.9 for explicit saves.                                                                                            |
 | ttl_days   | integer | no       | Expiration in days for `short_term` memories. Use 0 for default TTL or long-term memories.                                                                 |

--- a/data/tools/memory.search.md
+++ b/data/tools/memory.search.md
@@ -4,7 +4,7 @@
 
 Search stored memories for the current user when remembered user-specific context could improve the answer. You should retrieve memory proactively; the user does not need to ask what you remember.
 
-Use this for the user's preferences, projects, identity details, environment, relationships, tasks, prior corrections, and user-specific instructions that may affect the response.
+Use this for the user's preferences, projects, identity details, environment, relationships, prior corrections, and user-specific instructions that may affect the response.
 
 Do not use this as web search, public knowledge lookup, general conversation history, or a way to inspect Oswald's own identity/directives. Use web.search for current public facts and soul.read for Oswald's own identity.
 
@@ -14,5 +14,5 @@ Do not use this as web search, public knowledge lookup, general conversation his
 | -------- | ------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | query    | string  | no       | Semantic search query. Omit only when filtering by scope/category is enough.                                                                                               |
 | scope    | string  | no       | Optional scope filter: `short_term` or `long_term`.                                                                                                                        |
-| category | string  | no       | Optional category filter: `identity`, `system_rules`, `communication_preferences`, `durable_preferences`, `projects`, `relationships`, `environment`, `tasks`, or `notes`. |
+| category | string  | no       | Optional category filter: `identity`, `system_rules`, `communication_preferences`, `durable_preferences`, `projects`, `relationships`, `environment`, or `notes`. |
 | limit    | integer | no       | Maximum memories to return; defaults to 8.                                                                                                                                 |

--- a/data/tools/web.search.md
+++ b/data/tools/web.search.md
@@ -2,6 +2,18 @@
 
 ## Description
 
+Search the public web for current or uncertain factual information. Do not search when you can answer confidently from existing knowledge or tool results.
+
+Before searching, identify the specific facts required to answer the user's request. Form one concise, comprehensive initial query around the factual core. Include relevant discriminating details such as proper names, dates, versions, products, organizations, or locations so the first search has the best chance of retrieving everything needed.
+
+For requests containing several related facts, prefer a query that captures their shared subject and context. Split them into separate searches only when they are genuinely independent and cannot reasonably be answered from the same results.
+
+After every search, review the returned titles, URLs, and snippets before deciding whether more information is needed. Search again only when a specific, important fact remains unresolved and is necessary to answer accurately. A follow-up query must directly target that missing fact and should use useful terminology discovered in the previous results.
+
+Never issue minor reformulations of an already successful query. Do not repeat searches merely for additional confirmation, collect redundant sources, or search for facts already supported by adequate results. Once the available evidence is sufficient, answer the user.
+
+Use short, factual search language. Avoid emotional, conversational, or rhetorical phrasing. Returns numbered results containing a title, URL, and short snippet.
+
 **CRITICAL OPERATIONAL RULE - READ BEFORE SEARCHING:**
 
 You must evaluate the user's intent before executing a web search. DO NOT initiate a search if the query involves topics you would not search on a monitored corporate laptop. If the query falls into the restricted categories below, you must skip the search tool.
@@ -13,8 +25,6 @@ You must evaluate the user's intent before executing a web search. DO NOT initia
 - **Standard Criminal/Fraudulent Acts:** Arson, insurance fraud, financial crimes, or physical theft operations.
 - **Violence/Harm:** Weapons manufacturing (e.g., 3D-printed firearms, ghost guns), explosives crafting, organized violence, or targeted abuse and doxing.
 - **Contraband/Exploitation:** Sourcing illicit drugs, unregulated lethal substances (e.g., fentanyl, ricin), human trafficking networks, or exploitation material.
-
-Search the public web for current or uncertain factual information. Use short, precise queries focused on the factual core of the request. Use correct proper nouns, avoid emotional or rhetorical phrasing, and do not call this tool when you can answer confidently without external lookup. Returns numbered results with a title, URL, and short snippet.
 
 ## Parameters
 

--- a/internal/database/user_memory.go
+++ b/internal/database/user_memory.go
@@ -16,7 +16,7 @@ CREATE TABLE IF NOT EXISTS memory_entries (
 	id INTEGER PRIMARY KEY AUTOINCREMENT,
 	canonical_user_id TEXT NOT NULL,
 	scope TEXT NOT NULL CHECK (scope IN ('short_term', 'long_term')),
-	category TEXT NOT NULL CHECK (category IN ('identity', 'system_rules', 'communication_preferences', 'durable_preferences', 'projects', 'relationships', 'environment', 'tasks', 'notes')),
+	category TEXT NOT NULL CHECK (category IN ('identity', 'system_rules', 'communication_preferences', 'durable_preferences', 'projects', 'relationships', 'environment', 'notes')),
 	statement TEXT NOT NULL,
 	statement_key TEXT NOT NULL,
 	evidence TEXT NOT NULL,

--- a/internal/tools/builtin/usermemory/store.go
+++ b/internal/tools/builtin/usermemory/store.go
@@ -27,7 +27,7 @@ const (
 )
 
 // ValidCategories lists supported memory categories in display order.
-var ValidCategories = []string{"identity", "system_rules", "communication_preferences", "durable_preferences", "projects", "relationships", "environment", "tasks", "notes"}
+var ValidCategories = []string{"identity", "system_rules", "communication_preferences", "durable_preferences", "projects", "relationships", "environment", "notes"}
 
 // MemoryEntry is a single short-term or long-term user memory.
 type MemoryEntry struct {

--- a/internal/tools/builtin/usermemory/store_test.go
+++ b/internal/tools/builtin/usermemory/store_test.go
@@ -75,7 +75,7 @@ func TestStoreShortTermExpiry(t *testing.T) {
 	store := NewStore(filepath.Join(t.TempDir(), "oswald.db"), config.NewLogger(config.LevelError))
 	defer store.Close() // nolint:errcheck
 
-	_, err := store.SaveMemory(context.Background(), "usr_test", SaveRequest{Scope: ScopeShortTerm, Category: "tasks", Statement: "The user is testing expiry.", Evidence: "test", TTL: time.Nanosecond})
+	_, err := store.SaveMemory(context.Background(), "usr_test", SaveRequest{Scope: ScopeShortTerm, Category: "notes", Statement: "The user is testing expiry.", Evidence: "test", TTL: time.Nanosecond})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
removing task avoids confusion for the model, it kept thinking task was a way to perform actions. addresses #52