### PR TITLE
feat: recent tools in ## Recent Exchanges

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,16 +110,17 @@ Per request it does the following:
    - current speaker identity when available
    - user `system_rules` memory when available
 5. Load automatic retrieved context from recent SQLite-backed session turns
-6. Estimate prompt size against the active model budget
-7. Build the chat message array: system prompt, retrieved SQLite session context, current user prompt, and any current-turn images
-8. Call the LLM gateway with default-visible tools plus any MCP-discovered tools exposed for this request
-9. If the model emits tool calls:
+6. Pre-expose successful MCP tools from those recent turns when they remain visible and available to the current user
+7. Estimate prompt size against the active model budget
+8. Build the chat message array: system prompt, retrieved SQLite session context, current user prompt, and any current-turn images
+9. Call the LLM gateway with default-visible tools plus recent or dynamically discovered MCP tools exposed for this request
+10. If the model emits tool calls:
    - execute each tool handler
    - append tool results as `tool` messages
    - repeat until no tool calls remain or the consecutive tool-failure limit is hit
-10. If tool failures exhaust the retry budget, make one final model call with tools disabled
-11. Persist only the cleaned final user message, final assistant reply, and compact tool-name annotations to session memory
-12. Return the final `AgentResponse`
+11. If tool failures exhaust the retry budget, make one final model call with tools disabled
+12. Persist only the cleaned final user message, final assistant reply, and compact tool-name annotations to session memory
+13. Return the final `AgentResponse`
 
 Multimodal request notes:
 
@@ -190,7 +191,8 @@ Oswald keeps three distinct memory layers.
 - Stored in SQLite table `session_turns`
 - Keyed by gateway-provided `SessionKey` and canonical user ID
 - Stores only completed final user/assistant turn pairs
-- Recent completed exchanges are automatically included in the structured retrieved-memory block when budget permits
+- Recent completed exchanges are automatically included in the structured retrieved-memory block when budget permits, with a compact `Tools used:` annotation when applicable
+- Successful MCP tools from the latest four exchanges are pre-exposed on the initial model call only when they remain available to the current canonical user
 - Each stored turn has an optional `expires_at`; expired turns are deleted when recent session turns are read
 - Tool messages and intermediate reasoning are intentionally not persisted
 

--- a/data/tools/time.current.md
+++ b/data/tools/time.current.md
@@ -2,7 +2,17 @@
 
 ## Description
 
-Return the authoritative current date and time in the requested IANA timezone. Use this tool whenever an answer depends on the current date, current time, current weekday, or a timezone conversion of the current time. Do not estimate the current time from conversation context or use web search for it.
+Return the authoritative current date and time in a resolved IANA timezone.
+
+Use this tool whenever an answer depends on the current date, time, weekday, year,
+or a conversion of the current time. Resolve the timezone in this order:
+
+1. Use a timezone or location explicitly supplied in the current request.
+2. Otherwise call memory.search for the user's timezone or location.
+3. A remembered location may be mapped to an IANA timezone only when the
+   mapping is unambiguous.
+4. If the timezone remains unknown or ambiguous, ask the user for their
+   timezone or location. Do not call this tool until they answer.
 
 ## Parameters
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -241,6 +241,7 @@ type Agent struct {
 // MCPProvider resolves request-scoped MCP tools for the active canonical user.
 type MCPProvider interface {
 	DiscoveryTools(ctx context.Context, userID string) []llm.Tool
+	ResolveTools(ctx context.Context, userID string, names []string) []string
 	LLMTools(ctx context.Context, userID string, exposed map[string]bool) []llm.Tool
 	Execute(ctx context.Context, userID, name string, args map[string]interface{}, exposed map[string]bool) (string, bool, error)
 }
@@ -500,6 +501,7 @@ func (a *Agent) Process(requestID string, gateway string, sessionKey string, sen
 	if semanticQueryText == "" {
 		semanticQueryText = userPrompt
 	}
+	var recentToolNames []string
 	if a.userMemory != nil {
 		memoryContext, err := a.userMemory.BuildContext(ctx, senderID, sessionKey, semanticQueryText, usermemory.ContextOptions{
 			RecentTurns:        memoryRecentTurns,
@@ -509,10 +511,20 @@ func (a *Agent) Process(requestID string, gateway string, sessionKey string, sen
 			reqLog.Warn("agent.memory.context.failed", "failed to build retrieved memory context", config.F("status", "degraded"), config.ErrorField(err))
 		} else if strings.TrimSpace(memoryContext.Block) != "" {
 			dynamicSystemPrompt += "\n\n" + memoryContext.Block
+			recentToolNames = memoryContext.RecentToolNames
 			reqLog.Debug("agent.memory.context.loaded", "loaded retrieved memory context",
 				config.F("recent_turn_count", memoryContext.RecentTurnCount),
 			)
 		}
+	}
+	if a.mcpProvider != nil && len(recentToolNames) > 0 {
+		mcpCandidates := make([]string, 0, len(recentToolNames))
+		for _, name := range recentToolNames {
+			if !a.registry.HasHandler(name) {
+				mcpCandidates = append(mcpCandidates, name)
+			}
+		}
+		toolExposure.ExposeTools(a.mcpProvider.ResolveTools(ctx, senderID, mcpCandidates))
 	}
 
 	initialTools := a.toolsForRequest(ctx, senderID, toolExposure)

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -43,7 +43,7 @@ func TestProcessFinalAnswerPersistsCleanedSessionMemory(t *testing.T) {
 		t.Fatalf("expected current-turn image in prompt, got %+v", lastMessage.Images)
 	}
 
-	turns, err := store.RecentSessionTurns("session-1", 1, 1)
+	turns, err := store.RecentSessionTurns("user-1", "session-1", 1, 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -70,7 +70,7 @@ func TestProcessExecutesToolThenFinalAnswerAndStreamsEvents(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("register tool: %v", err)
 	}
-	agent, _ := newTestAgent(t, chat, nil, reg)
+	agent, store := newTestAgent(t, chat, nil, reg)
 
 	var chunks []StreamChunk
 	resp, err := agent.Process("req-1", "websocket", "session-1", "user-1", "Display", "question", nil, func(chunk StreamChunk) {
@@ -103,6 +103,13 @@ func TestProcessExecutesToolThenFinalAnswerAndStreamsEvents(t *testing.T) {
 	}
 	if toolCallIndex < 0 || toolResultIndex < 0 || toolResultIndex <= toolCallIndex || chunks[toolResultIndex].Tool.ResultText != "lookup result" {
 		t.Fatalf("unexpected stream chunks: %+v", chunks)
+	}
+	turns, err := store.RecentSessionTurns("user-1", "session-1", 1, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(turns) != 1 || strings.Join(turns[0].ToolNames, ",") != "test.lookup" {
+		t.Fatalf("successful tool annotation was not persisted: %+v", turns)
 	}
 }
 
@@ -168,7 +175,7 @@ func TestProcessRetriesEmptyVisibleResponse(t *testing.T) {
 		t.Fatalf("unexpected retry prompt: %+v", lastMessage)
 	}
 
-	turns, err := store.RecentSessionTurns("session-1", 1, 1)
+	turns, err := store.RecentSessionTurns("user-1", "session-1", 1, 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -204,7 +211,7 @@ func TestProcessFallsBackAfterEmptyRetry(t *testing.T) {
 		t.Fatalf("expected fallback content chunk, got %+v", chunks)
 	}
 
-	turns, err := store.RecentSessionTurns("session-1", 1, 1)
+	turns, err := store.RecentSessionTurns("user-1", "session-1", 1, 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -270,7 +277,7 @@ func TestProcessUsesFriendlyFallbackAfterRepeatedOllamaParserError(t *testing.T)
 	if contentChunks != 1 {
 		t.Fatalf("fallback chunks = %d, want 1: %+v", contentChunks, chunks)
 	}
-	turns, err := store.RecentSessionTurns("session-1", 1, 1)
+	turns, err := store.RecentSessionTurns("user-1", "session-1", 1, 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -356,7 +363,7 @@ func TestProcessUsesImageSizeFallbackAfterFiveStoppedRunnerAttempts(t *testing.T
 	if contentChunks != 1 {
 		t.Fatalf("fallback chunks = %d, want 1", contentChunks)
 	}
-	turns, err := store.RecentSessionTurns("session-1", 1, 1)
+	turns, err := store.RecentSessionTurns("user-1", "session-1", 1, 1)
 	if err != nil || len(turns) != 1 || turns[0].AssistantText != imageSizeFallback {
 		t.Fatalf("fallback turn was not persisted: turns=%+v err=%v", turns, err)
 	}
@@ -553,6 +560,51 @@ func TestProcessUsesDynamicMCPDiscoveryTools(t *testing.T) {
 	}
 }
 
+func TestProcessPreExposesMCPToolsFromRecentSessionTurns(t *testing.T) {
+	chat := &fakeChatter{responses: []*llm.ChatResponse{{Model: "test-model", Message: llm.ChatMessage{Role: "assistant", Content: "done"}}}}
+	agent, store := newTestAgent(t, chat, nil, nil)
+	agent.mcpProvider = &fakeMCPProvider{}
+	if err := store.AppendSessionTurn(context.Background(), "session-mcp", "user-1", "prior question", "prior answer", []string{"home.turn_on", "home.tools", "web.search"}, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := agent.Process("req-mcp", "websocket", "session-mcp", "user-1", "User", "again", nil, nil); err != nil {
+		t.Fatalf("process: %v", err)
+	}
+	request := primaryRequests(chat.requests)[0]
+	if !requestHasTool(request, "home.turn_on") {
+		t.Fatalf("first request did not pre-expose recent MCP tool: %+v", toolNames(request))
+	}
+	if !strings.Contains(request.Messages[0].Content, "Tools used: home.turn_on, home.tools, web.search") {
+		t.Fatalf("system prompt missing compact tool annotation:\n%s", request.Messages[0].Content)
+	}
+}
+
+func TestProcessDoesNotPreExposeMCPToolOutsideRecentFourTurns(t *testing.T) {
+	chat := &fakeChatter{responses: []*llm.ChatResponse{{Model: "test-model", Message: llm.ChatMessage{Role: "assistant", Content: "done"}}}}
+	agent, store := newTestAgent(t, chat, nil, nil)
+	agent.mcpProvider = &fakeMCPProvider{}
+	if err := store.AppendSessionTurn(context.Background(), "session-mcp", "user-1", "old question", "old answer", []string{"home.turn_on"}, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 4; i++ {
+		if err := store.AppendSessionTurn(context.Background(), "session-mcp", "user-1", "recent question", "recent answer", nil, time.Hour); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if _, err := agent.Process("req-mcp", "websocket", "session-mcp", "user-1", "User", "again", nil, nil); err != nil {
+		t.Fatalf("process: %v", err)
+	}
+	request := primaryRequests(chat.requests)[0]
+	if requestHasTool(request, "home.turn_on") {
+		t.Fatalf("first request exposed tool from fifth-oldest turn: %+v", toolNames(request))
+	}
+	if strings.Contains(request.Messages[0].Content, "old question") {
+		t.Fatalf("system prompt included fifth-oldest turn:\n%s", request.Messages[0].Content)
+	}
+}
+
 func toolCallResponse(id, name string, args map[string]interface{}) *llm.ChatResponse {
 	return &llm.ChatResponse{Model: "test-model", Message: llm.ChatMessage{Role: "assistant", ToolCalls: []llm.ToolCall{{ID: id, Function: llm.ToolFunction{Name: name, Arguments: args}}}}}
 }
@@ -614,6 +666,15 @@ type fakeMCPProvider struct{}
 
 func (p *fakeMCPProvider) DiscoveryTools(ctx context.Context, userID string) []llm.Tool {
 	return []llm.Tool{{Type: "function", Function: llm.ToolDefinition{Name: "home.tools", Description: "Search Home Assistant tools", Parameters: llm.ToolParameters{Type: "object"}}}}
+}
+
+func (p *fakeMCPProvider) ResolveTools(ctx context.Context, userID string, names []string) []string {
+	for _, name := range names {
+		if name == "home.turn_on" {
+			return []string{name}
+		}
+	}
+	return nil
 }
 
 func (p *fakeMCPProvider) LLMTools(ctx context.Context, userID string, exposed map[string]bool) []llm.Tool {

--- a/internal/mcp/provider.go
+++ b/internal/mcp/provider.go
@@ -39,6 +39,50 @@ func (p *Provider) DiscoveryTools(ctx context.Context, userID string) []llm.Tool
 	return tools
 }
 
+// ResolveTools returns historical MCP tool names that remain available to userID.
+func (p *Provider) ResolveTools(ctx context.Context, userID string, names []string) []string {
+	if p == nil || p.manager == nil || len(names) == 0 {
+		return nil
+	}
+
+	servers := make([]string, 0)
+	seenServers := map[string]bool{}
+	candidates := make([]string, 0, len(names))
+	seenCandidates := map[string]bool{}
+	for _, name := range names {
+		name = strings.TrimSpace(name)
+		server, remote, ok := splitToolName(name)
+		if !ok || strings.EqualFold(remote, "tools") || seenCandidates[name] {
+			continue
+		}
+		seenCandidates[name] = true
+		candidates = append(candidates, name)
+		if !seenServers[server] {
+			seenServers[server] = true
+			servers = append(servers, server)
+		}
+	}
+
+	available := map[string]bool{}
+	for _, server := range servers {
+		specs, info, err := p.manager.ServerToolSpecs(ctx, userID, server)
+		if err != nil || info.Status != serverStatusConnected {
+			continue
+		}
+		for _, spec := range specs {
+			available[spec.Name] = true
+		}
+	}
+
+	resolved := make([]string, 0, len(candidates))
+	for _, name := range candidates {
+		if available[name] {
+			resolved = append(resolved, name)
+		}
+	}
+	return resolved
+}
+
 func (p *Provider) LLMTools(ctx context.Context, userID string, exposed map[string]bool) []llm.Tool {
 	if p == nil || p.manager == nil || len(exposed) == 0 {
 		return nil

--- a/internal/mcp/provider_test.go
+++ b/internal/mcp/provider_test.go
@@ -52,6 +52,34 @@ func TestProviderDiscoveryToolsAreScopedToVisibleEnabledServers(t *testing.T) {
 	}
 }
 
+func TestProviderResolveToolsUsesCurrentVisibleCatalog(t *testing.T) {
+	store, err := NewStore(filepath.Join(t.TempDir(), "oswald.db"), "12345678901234567890123456789012", config.NewLogger(config.LevelError).Server("test"))
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+	store.SetResolverForTest(staticResolver{"example.com": {"93.184.216.34"}})
+	ctx := context.Background()
+	cfg, err := store.Save(ctx, ServerConfig{Scope: ScopeUser, OwnerUserID: "user_1", Name: "home", Transport: TransportStreamableHTTP, URL: "https://example.com/home", Enabled: true})
+	if err != nil {
+		t.Fatalf("save home: %v", err)
+	}
+	manager := NewManagerFromStore(store, config.NewLogger(config.LevelError))
+	manager.sessions[scopeKey(cfg)] = &server{config: cfg, tools: []ToolSpec{
+		{Name: "home.turn_on", Server: "home", RemoteName: "turn_on"},
+		{Name: "home.weather", Server: "home", RemoteName: "weather"},
+	}}
+	provider := NewProvider(manager)
+
+	resolved := provider.ResolveTools(ctx, "user_1", []string{"home.turn_on", "home.tools", "web.search", "home.missing", "home.turn_on"})
+	if len(resolved) != 1 || resolved[0] != "home.turn_on" {
+		t.Fatalf("resolved tools = %+v", resolved)
+	}
+	if resolved := provider.ResolveTools(ctx, "user_2", []string{"home.turn_on"}); len(resolved) != 0 {
+		t.Fatalf("resolved another user's tools: %+v", resolved)
+	}
+}
+
 func TestSearchToolsReturnsAllToolsWithoutQuery(t *testing.T) {
 	catalog := []registryEntry{
 		{name: "home.turn_on", description: "Turn on a light"},

--- a/internal/mcp/result.go
+++ b/internal/mcp/result.go
@@ -54,7 +54,7 @@ func flattenToolResult(result *gomcp.CallToolResult) (string, error) {
 		if text == "" {
 			text = "MCP tool returned an unspecified error."
 		}
-		text = "Error: " + text
+		return "", fmt.Errorf("MCP tool returned an error: %s", truncate(text, maxToolResultChars))
 	}
 	if text == "" {
 		text = "MCP tool returned no content."

--- a/internal/mcp/result_test.go
+++ b/internal/mcp/result_test.go
@@ -25,11 +25,8 @@ func TestFlattenToolResultTextStructuredErrorAndEmpty(t *testing.T) {
 	}
 
 	toolErr, err := flattenToolResult(&gomcp.CallToolResult{IsError: true})
-	if err != nil {
-		t.Fatalf("flatten error result returned error: %v", err)
-	}
-	if toolErr != "Error: MCP tool returned an unspecified error." {
-		t.Fatalf("flatten error result = %q", toolErr)
+	if err == nil || !strings.Contains(err.Error(), "MCP tool returned an unspecified error") {
+		t.Fatalf("flatten error result = %q, %v", toolErr, err)
 	}
 
 	empty, err := flattenToolResult(&gomcp.CallToolResult{})

--- a/internal/tools/builtin/usermemory/store.go
+++ b/internal/tools/builtin/usermemory/store.go
@@ -77,6 +77,7 @@ type ContextOptions struct {
 type RetrievedContext struct {
 	Block           string
 	RecentTurnCount int
+	RecentToolNames []string
 }
 
 // SaveRequest describes a user memory write.
@@ -468,8 +469,8 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 	return nil
 }
 
-// RecentSessionTurns returns newest completed exchanges, newest first.
-func (s *Store) RecentSessionTurns(sessionID string, offset int, count int) ([]SessionTurn, error) {
+// RecentSessionTurns returns a user's newest completed session exchanges, newest first.
+func (s *Store) RecentSessionTurns(userID, sessionID string, offset int, count int) ([]SessionTurn, error) {
 	if offset < 1 {
 		offset = 1
 	}
@@ -484,8 +485,8 @@ func (s *Store) RecentSessionTurns(sessionID string, offset int, count int) ([]S
 	}
 	rows, err := s.sql.Query(`
 SELECT id, session_id, canonical_user_id, user_text, assistant_text, tool_names, importance, topic_tags, created_at, expires_at
-FROM session_turns WHERE session_id = ? ORDER BY created_at DESC LIMIT ? OFFSET ?
-`, sessionID, count, offset-1)
+FROM session_turns WHERE canonical_user_id = ? AND session_id = ? ORDER BY created_at DESC, id DESC LIMIT ? OFFSET ?
+`, userID, sessionID, count, offset-1)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read session turns: %w", err)
 	}
@@ -514,13 +515,17 @@ func (s *Store) BuildContext(ctx context.Context, userID, sessionID, query strin
 		opts.ContextBudgetChars = 12000
 	}
 
-	recent, err := s.RecentSessionTurns(sessionID, 1, opts.RecentTurns)
+	recent, err := s.RecentSessionTurns(userID, sessionID, 1, opts.RecentTurns)
 	if err != nil {
 		return RetrievedContext{}, err
 	}
 
 	block := s.renderContextBlock(recent, opts.ContextBudgetChars)
-	return RetrievedContext{Block: block, RecentTurnCount: len(recent)}, nil
+	var toolNames []string
+	for _, turn := range recent {
+		toolNames = append(toolNames, turn.ToolNames...)
+	}
+	return RetrievedContext{Block: block, RecentTurnCount: len(recent), RecentToolNames: uniqueStrings(toolNames)}, nil
 }
 
 func (s *Store) renderContextBlock(recent []SessionTurn, maxChars int) string {
@@ -552,7 +557,11 @@ func writeEntries(b *strings.Builder, entries []MemoryEntry) {
 func writeTurns(b *strings.Builder, turns []SessionTurn) {
 	for i := len(turns) - 1; i >= 0; i-- {
 		turn := turns[i]
-		fmt.Fprintf(b, "User: %s\nAssistant: %s\n\n", strings.TrimSpace(turn.UserText), strings.TrimSpace(turn.AssistantText))
+		fmt.Fprintf(b, "User: %s\nAssistant: %s\n", strings.TrimSpace(turn.UserText), strings.TrimSpace(turn.AssistantText))
+		if len(turn.ToolNames) > 0 {
+			fmt.Fprintf(b, "Tools used: %s\n", strings.Join(turn.ToolNames, ", "))
+		}
+		b.WriteString("\n")
 	}
 }
 

--- a/internal/tools/builtin/usermemory/store_test.go
+++ b/internal/tools/builtin/usermemory/store_test.go
@@ -113,6 +113,41 @@ func TestStoreSessionContextIncludesSummaryAndRecentTurn(t *testing.T) {
 	}
 }
 
+func TestStoreSessionContextIncludesToolAnnotationsAndScopesUser(t *testing.T) {
+	store := NewStore(filepath.Join(t.TempDir(), "oswald.db"), config.NewLogger(config.LevelError))
+	defer store.Close() // nolint:errcheck
+
+	ctx := context.Background()
+	if err := store.AppendSessionTurn(ctx, "shared-session", "user-1", "first question", "first answer", []string{"github.get_issue", "web.search"}, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AppendSessionTurn(ctx, "shared-session", "user-2", "private question", "private answer", []string{"other.secret"}, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+
+	retrieved, err := store.BuildContext(ctx, "user-1", "shared-session", "follow up", ContextOptions{RecentTurns: 4, ContextBudgetChars: 4000})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(retrieved.Block, "Assistant: first answer\nTools used: github.get_issue, web.search") {
+		t.Fatalf("tool annotation missing from context:\n%s", retrieved.Block)
+	}
+	if strings.Contains(retrieved.Block, "private") || strings.Contains(retrieved.Block, "other.secret") {
+		t.Fatalf("context included another user's turn:\n%s", retrieved.Block)
+	}
+	if strings.Join(retrieved.RecentToolNames, ",") != "github.get_issue,web.search" {
+		t.Fatalf("recent tool names = %+v", retrieved.RecentToolNames)
+	}
+
+	turns, err := store.RecentSessionTurns("user-2", "shared-session", 1, 4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(turns) != 1 || turns[0].UserText != "private question" {
+		t.Fatalf("unexpected scoped turns: %+v", turns)
+	}
+}
+
 func TestBuildContextDoesNotEmbedQuery(t *testing.T) {
 	embedder := &countingMemoryEmbedder{}
 	store, err := NewSQLiteStore(filepath.Join(t.TempDir(), "oswald.db"), embedder, "fake-embed", config.NewLogger(config.LevelError))


### PR DESCRIPTION
ensures the model does not have to search everytime a MCP tool is used, so frequently used can be instantly executed. addresses #52 